### PR TITLE
Add access to neighbors of remote cells

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8775,11 +8775,11 @@ private:
 		}
 		#endif
 
+		this->user_neigh_of[neighborhood_id][cell].clear();
+		this->user_neigh_to[neighborhood_id][cell].clear();
 		if (this->cell_data.count(cell) == 0) {
 			return;
 		}
-		this->user_neigh_of[neighborhood_id][cell].clear();
-		this->user_neigh_to[neighborhood_id][cell].clear();
 		if (cell != this->get_child(cell)) {
 			return;
 		}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -9495,6 +9495,10 @@ private:
 			this->cells_not_to_refine.clear();
 
 			for (const auto& cell: donts) {
+				// Skip non-local cells
+				if (this->cell_data.count(cell) == 0) {
+					continue;
+				}
 				std::set<uint64_t> all_neighbors;
 
 				const auto* const neighs_of = this->get_neighbors_of(cell);

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2644,7 +2644,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8700,6 +8700,8 @@ private:
 		// if (this->cell_process.at(cell) != this->rank) {
 		// 	return;
 		// }
+		this->neighbors_of[cell].clear();
+		this->neighbors_to[cell].clear();
 
 		if (cell != this->get_child(cell)) {
 			return;
@@ -8772,6 +8774,15 @@ private:
 			abort();
 		}
 		#endif
+
+		if (this->cell_process.count(cell) == 0) {
+			return;
+		}
+		this->user_neigh_of[neighborhood_id][cell].clear();
+		this->user_neigh_to[neighborhood_id][cell].clear();
+		if (cell != this->get_child(cell)) {
+			return;
+		}
 
 		// find neighbors_of, should be in order given by user
 		this->user_neigh_of[neighborhood_id][cell]

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,8 +826,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
-
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_to.count(cell) == 0) {
@@ -2644,7 +2643,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_data.count(cell) == 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8777,7 +8776,7 @@ private:
 
 		this->user_neigh_of[neighborhood_id][cell].clear();
 		this->user_neigh_to[neighborhood_id][cell].clear();
-		if (this->cell_data.count(cell) == 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return;
 		}
 		if (cell != this->get_child(cell)) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2611,6 +2611,13 @@ public:
 		return true;
 	}
 
+	const std::vector<std::pair<uint64_t, int>>& get_face_neighbors_of (const uint64_t cell) const
+	{
+		// Could add checks or return a nullptr / empty vector / whatever
+		// But honestly it's just better to throw
+		return face_neighbors_of.at(cell);
+	}
+
 	/*!
 	Returns cells which share a face with the given cell.
 
@@ -3545,6 +3552,7 @@ public:
 				this->cell_data[parent];
 				this->neighbors_of[parent] = new_neighbors_of;
 				this->neighbors_to[parent] = new_neighbors_to;
+				this->face_neighbors_of[parent] = this->find_face_neighbors_of(parent);
 
 				// add user neighbor lists
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3595,6 +3603,7 @@ public:
 
 				this->neighbors_of.erase(refined);
 				this->neighbors_to.erase(refined);
+				this->face_neighbors_of.erase(refined);
 
 				// remove also from user's neighborhood
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3612,6 +3621,7 @@ public:
 		for (const uint64_t unrefined: this->all_to_unrefine) {
 			this->neighbors_of.erase(unrefined);
 			this->neighbors_to.erase(unrefined);
+			this->face_neighbors_of.erase(unrefined);
 			// also from user neighborhood
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
 				item = this->user_hood_of.begin();
@@ -4336,6 +4346,7 @@ public:
 			this->cell_data.erase(removed_cell);
 			this->neighbors_of.erase(removed_cell);
 			this->neighbors_to.erase(removed_cell);
+			this->face_neighbors_of.erase(removed_cell);
 
 			// also user neighbor lists
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -7043,6 +7054,9 @@ private:
 		>
 	> neighbors_of;
 
+	// Cached face neighbors on this process
+	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, int>>> face_neighbors_of;
+
 	/*
 	Offsets of cells that are considered as neighbors of a cell and
 	offsets of cells that consider a cell as a neighbor
@@ -8033,6 +8047,7 @@ private:
 			#endif
 
 			this->neighbors_to[item.first] = this->find_neighbors_to(item.first, this->neighborhood_to);
+			this->face_neighbors_of[item.first] = this->find_face_neighbors_of(item.first);
 		}
 		#ifdef DEBUG
 		if (!this->verify_neighbors()) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,8 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		//if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,7 +827,8 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		//if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -2644,9 +2646,10 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_data.count(cell) == 0) {
-			return ret_val;
-		}
+		// Allow face neighbour searches for non-local cells
+		// if (this->cell_data.count(cell) == 0) {
+		// 	return ret_val;
+		// }
 
 
 		// Iterate through neighbours and only return those with a single 1
@@ -2828,6 +2831,7 @@ public:
 			return ret_val;
 		}
 
+		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -2880,6 +2884,7 @@ public:
 			return ret_val;
 		}
 
+		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -8697,9 +8702,9 @@ private:
 			return;
 		}
 
-		if (this->cell_process.at(cell) != this->rank) {
-			return;
-		}
+		// if (this->cell_process.at(cell) != this->rank) {
+		// 	return;
+		// }
 
 		if (cell != this->get_child(cell)) {
 			return;
@@ -8711,7 +8716,6 @@ private:
 			found_neighbors_of.push_back(i.first);
 		}
 		this->neighbors_to[cell] = this->find_neighbors_to(cell, this->neighborhood_to);
-
 		#ifdef DEBUG
 		if (
 			!this->verify_neighbors(
@@ -10280,7 +10284,24 @@ private:
 	}
 
 public:
-	/*!
+	void force_update_cell_neighborhoods(const std::vector<uint64_t> cells)
+	{
+		for (uint i=0; i<cells.size(); i++) {
+			this->update_neighbors(cells[i]);
+		}
+		// also remote neighbor data of user neighborhoods
+		for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
+			item = this->user_hood_of.begin();
+			item != this->user_hood_of.end();
+			item++
+		) {
+			for (uint i=0; i<cells.size(); i++) {
+				this->update_user_neighbors(cells[i],item->first);
+			}
+		}
+	}
+
+        /*!
 	Returns the smallest existing cell at given indices between given refinement levels inclusive.
 
 	Returns error_cell if no cell between given refinement ranges exists or an index is outside of

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8794,10 +8794,6 @@ private:
 		}
 
 		this->neighbors_of[cell] = this->find_neighbors_of(cell, this->neighborhood_of, this->max_ref_lvl_diff);
-		std::vector<uint64_t> found_neighbors_of;
-		for (const auto& i: this->neighbors_of[cell]) {
-			found_neighbors_of.push_back(i.first);
-		}
 		this->neighbors_to[cell] = this->find_neighbors_to(cell, this->neighborhood_to);
 		#ifdef DEBUG
 		if (
@@ -8832,6 +8828,8 @@ private:
 			}
 		}
 		#endif
+		// Update also cached face neighbors
+		this->face_neighbors_of[cell] = this->find_face_neighbors_of(cell);
 	}
 
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4373,9 +4373,10 @@ public:
 
 		this->allocate_copies_of_remote_neighbors();
 		this->update_cell_pointers();
-		for (const auto& item: this->user_hood_of) {
-			this->allocate_copies_of_remote_neighbors(item.first);
-		}
+		// All remote neighbors of user hoods are already included in base hood
+		// for (const auto& item: this->user_hood_of) {
+		//	this->allocate_copies_of_remote_neighbors(item.first);
+		// }
 
 		#ifdef DEBUG
 		if (!this->is_consistent()) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_data.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,7 +826,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_data.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -2644,7 +2644,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_process.count(cell) == 0) {
+		if (this->cell_data.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8775,7 +8775,7 @@ private:
 		}
 		#endif
 
-		if (this->cell_process.count(cell) == 0) {
+		if (this->cell_data.count(cell) == 0) {
 			return;
 		}
 		this->user_neigh_of[neighborhood_id][cell].clear();

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,6 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		//if (this->cell_data.count(cell) > 0) {
 		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -827,7 +826,6 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		//if (this->cell_data.count(cell) > 0) {
 		if (this->cell_process.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
@@ -2646,11 +2644,9 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		// Allow face neighbour searches for non-local cells
-		// if (this->cell_data.count(cell) == 0) {
-		// 	return ret_val;
-		// }
-
+		if (this->cell_process.count(cell) > 0) {
+			return ret_val;
+		}
 
 		// Iterate through neighbours and only return those with a single 1
 		// index.
@@ -2831,7 +2827,6 @@ public:
 			return ret_val;
 		}
 
-		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -2884,7 +2879,6 @@ public:
 			return ret_val;
 		}
 
-		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -8702,6 +8696,7 @@ private:
 			return;
 		}
 
+		// Allow neighbors of remote cells to be evaluated
 		// if (this->cell_process.at(cell) != this->rank) {
 		// 	return;
 		// }

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -7490,7 +7490,7 @@ private:
 		int worker_procs = this->comm_size;
 		if(getenv("DCCRG_PROCS") != NULL) {
 			const int dccrg_procs = atoi(getenv("DCCRG_PROCS"));
-			if(dccrg_procs > 0 && dccrg_procs < this->comm_size)
+			if(dccrg_procs > 0 && (uint)dccrg_procs < this->comm_size)
 				worker_procs = dccrg_procs;
 		}
 		const int zoltan_worker = (this->rank < this->comm_size - worker_procs) ? 0 : 1;


### PR DESCRIPTION
Accessing neighbors of remote cells is required for Ghost translation. Instead of storing all neighbors for all cells, this gives an interface for manually updating neighbors for a list of cells, and allowing access to them.